### PR TITLE
specifies cmake directory in region profiling.md

### DIFF
--- a/tutorial/region_profiling.md
+++ b/tutorial/region_profiling.md
@@ -54,7 +54,7 @@ Caliper installation directory. If the Caliper installation directory is not
 already in the CMake package search path you can point the CMake executable to
 it with `-Dcaliper_DIR`:
 
-    $ cmake -Dcaliper_DIR=/path/to/caliper/share/cmake/caliper
+    $ cmake -Dcaliper_DIR=/path/to/caliper/share/cmake/caliper .
 
 Without CMake, link the `libcaliper.so` library to the target code:
 


### PR DESCRIPTION
I was running this line:

``` 
cmake -Dcaliper_DIR=/path/to/caliper/share/cmake/caliper 
```

and I needed to specify the directory in order for it to work.